### PR TITLE
fix: 修正servlet找不到的问题

### DIFF
--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="github" />
+      <option name="name" value="GitHub OWNER Apache Maven Packages" />
+      <option name="url" value="https://maven.pkg.github.com/WangTingZheng/MyOrm" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="central" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+  </component>
+</project>

--- a/.idea/libraries/Maven__javax_servlet_javax_servlet_api_4_0_1.xml
+++ b/.idea/libraries/Maven__javax_servlet_javax_servlet_api_4_0_1.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: javax.servlet:javax.servlet-api:4.0.1">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/javax/servlet/javax.servlet-api/4.0.1/javax.servlet-api-4.0.1.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/javax/servlet/javax.servlet-api/4.0.1/javax.servlet-api-4.0.1-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/javax/servlet/javax.servlet-api/4.0.1/javax.servlet-api-4.0.1-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__javax_servlet_jsp_javax_servlet_jsp_api_2_3_3.xml
+++ b/.idea/libraries/Maven__javax_servlet_jsp_javax_servlet_jsp_api_2_3_3.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: javax.servlet.jsp:javax.servlet.jsp-api:2.3.3">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/javax/servlet/jsp/javax.servlet.jsp-api/2.3.3/javax.servlet.jsp-api-2.3.3.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/javax/servlet/jsp/javax.servlet.jsp-api/2.3.3/javax.servlet.jsp-api-2.3.3-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/javax/servlet/jsp/javax.servlet.jsp-api/2.3.3/javax.servlet.jsp-api-2.3.3-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/WebPage_Client_Test.iml
+++ b/WebPage_Client_Test.iml
@@ -25,8 +25,8 @@
     </facet>
   </component>
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_5">
-    <output url="file://$MODULE_DIR$/web/WEB-INF/classes" />
-    <output-test url="file://$MODULE_DIR$/web/WEB-INF/classes" />
+    <output url="file://$MODULE_DIR$/target/classes" />
+    <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
@@ -37,18 +37,20 @@
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Spring-5.2.3.RELEASE" level="project" />
     <orderEntry type="library" name="lib" level="project" />
+    <orderEntry type="library" name="servlet-api" level="project" />
+    <orderEntry type="library" name="jsp-api" level="project" />
     <orderEntry type="library" name="Maven: org.apache.struts:struts2-core:2.5.22" level="project" />
     <orderEntry type="library" name="Maven: org.freemarker:freemarker:2.3.30" level="project" />
-    <orderEntry type="library" name="Maven: ognl:ognl:3.1.15" level="project" />
     <orderEntry type="library" name="Maven: commons-fileupload:commons-fileupload:1.4" level="project" />
     <orderEntry type="library" name="Maven: org.apache.commons:commons-lang3:3.10" level="project" />
     <orderEntry type="library" name="Maven: commons-io:commons-io:2.7" level="project" />
     <orderEntry type="library" name="Maven: org.apache.logging.log4j:log4j-core:2.13.3" level="project" />
     <orderEntry type="library" name="Maven: org.apache.logging.log4j:log4j-api:2.13.3" level="project" />
     <orderEntry type="library" name="Maven: org.javassist:javassist:3.27.0-GA" level="project" />
+    <orderEntry type="library" name="Maven: ognl:ognl:3.1.15" level="project" />
     <orderEntry type="library" name="Maven: mysql:mysql-connector-java:8.0.18" level="project" />
     <orderEntry type="library" name="Maven: com.google.protobuf:protobuf-java:3.6.1" level="project" />
-    <orderEntry type="library" name="servlet-api" level="project" />
-    <orderEntry type="library" name="jsp-api" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: javax.servlet:javax.servlet-api:4.0.1" level="project" />
+    <orderEntry type="library" name="Maven: javax.servlet.jsp:javax.servlet.jsp-api:2.3.3" level="project" />
   </component>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -24,12 +24,7 @@
             <version>2.3.30</version>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/ognl/ognl -->
-        <dependency>
-            <groupId>ognl</groupId>
-            <artifactId>ognl</artifactId>
-            <version>3.2.14</version>
-        </dependency>
+
 
         <!-- https://mvnrepository.com/artifact/commons-fileupload/commons-fileupload -->
         <dependency>
@@ -87,11 +82,14 @@
             <version>8.0.18</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/javax.servlet/javax.servlet-api -->
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
-            <version>2.5</version>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>4.0.1</version>
+            <scope>provided</scope>
         </dependency>
+
         <!--    jsp 依赖-->
         <!-- https://mvnrepository.com/artifact/javax.servlet.jsp/javax.servlet.jsp-api -->
         <dependency>

--- a/src/main/java/guoyachen/mvc/servlet/LoginServlet.java
+++ b/src/main/java/guoyachen/mvc/servlet/LoginServlet.java
@@ -19,10 +19,7 @@ import java.util.List;
  * @Feature:
  */
 
-
-
 public class LoginServlet extends HttpServlet {
-
     public void doPost(HttpServletRequest req, HttpServletResponse resp)
     {
         String path = "index.jsp";

--- a/web/WEB-INF/web.xml
+++ b/web/WEB-INF/web.xml
@@ -9,19 +9,16 @@
     </filter>
     <filter-mapping>
         <filter-name>struts2</filter-name>
-        <url-pattern>/*</url-pattern>
+        <url-pattern>*.action</url-pattern>
     </filter-mapping>
     
     <servlet>
         <servlet-name>login</servlet-name>
-        <!--此处的内容必须要和部署后的位置对应 -->
         <servlet-class>guoyachen.mvc.servlet.LoginServlet</servlet-class>
     </servlet>
 
-    <!--//TODO:查出来为什么这个mapping是失效的 -->
     <servlet-mapping>
         <servlet-name>login</servlet-name>
-        <url-pattern>/WebPage_Client_Test_war_exploded/loginServlet/</url-pattern>
+        <url-pattern>/LoginServlet</url-pattern>
     </servlet-mapping>
-
 </web-app>

--- a/web/index.jsp
+++ b/web/index.jsp
@@ -31,7 +31,7 @@
     <div class="col-md-4"></div>
 
     <section class="login-form">
-      <form method="post" action="loginServlet" role="login">
+      <form action="${pageContext.request.contextPath}/LoginServlet" method="post" role="login">
         <br>
         <input type="string" id="username" name="username" placeholder="用户名" required class="form-control input-lg" />
 


### PR DESCRIPTION
原因：把struct2的过滤设置为了`*`导致系统把servlet的路径看成了action的路径，然而action又没定义，就找不到了
修正：
1.修正action的过滤为`*.action`，只把后缀名为action的url当作action的页面
2.升级servlet-api版本为4.0.1
3.去掉重复的依赖
4.在index.jsp中的action的url中设置自动补全，让开发者只关心servlet的变化而不用关心项目本身url的变化